### PR TITLE
[Chore]settings.py/isauthenticated를default로 수정

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -145,10 +145,10 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
-    # 'DEFAULT_PERMISSION_CLASSES': [
-    #     # 'rest_framework.permissions.IsAuthenticated',
+     'DEFAULT_PERMISSION_CLASSES': [
+          'rest_framework.permissions.IsAuthenticated',
     #     'rest_framework.permissions.AllowAny',
-    # ]
+     ]
 }
 
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
token 전달안할시 발생하는 에러코드를 500에서 401로 수정하기 위하여 default permission_classes를 수정하였습니다.

로그인 회원가입 잘되는 것 확인했습니당